### PR TITLE
fix to make bootstrap 3 glyphicons working on lighttpd

### DIFF
--- a/lighttpd.conf
+++ b/lighttpd.conf
@@ -5,7 +5,7 @@ $HTTP["host"] =~ "example.com$" {
         alias.url = ()
         url.redirect = ()
         url.rewrite-once = (
-                "^/(css|img|js)/.*\.(jpg|jpeg|gif|png|swf|avi|mpg|mpeg|mp3|flv|ico|css|js)$" => "$0",
+                "^/(css|img|js|fonts)/.*\.(jpg|jpeg|gif|png|swf|avi|mpg|mpeg|mp3|flv|ico|css|js|woff|ttf)$" => "$0",
                 "^/(favicon\.ico|robots\.txt|sitemap\.xml)$" => "$0",
                 "^/[^\?]*(\?.*)?$" => "index.php/$1"
         )


### PR DESCRIPTION
Changed lighttpd rewrite condition for `.woff` and `.ttf` files in the `fonts`directory. I had to make this change to get bootstrap 3 glyphicons working in my laravel templates.
